### PR TITLE
Added a catch for redis on error

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,10 @@ Throttle.configure = function(config) {
   delete config.port
   delete config.host
   this.rdb = redis.createClient(port, host, config)
+
+  this.rdb.on('error', function(err){
+    console.log('redis-throttle Redis connection failed, error: ' + err );
+  });
 }
 
 Throttle.prototype.increment = function(n, callback) {


### PR DESCRIPTION
I found that it does no retry the connection if one does not catch the
`redisClient.on('error'...)` instead the app craches.

There is probably ways to handle this higher up in the chain, but i
like node-redis to handle it.

To repro this, just start a client using redis-throttle and kill the
redis server.

What do you think?
